### PR TITLE
Add support for Event<any>

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -130,7 +130,8 @@ export class Event<T = undefined> {
      * be omitted.
      * @returns True if the event had listeners emitted to, false otherwise.
      */
-    public readonly emit: [T] extends [{}|null]
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    public readonly emit: [T] extends [{} | null]
         ? (emitting: T) => boolean
         : () => boolean = ((
         emitting?: T,
@@ -143,5 +144,6 @@ export class Event<T = undefined> {
         // remove all listeners that only wanted to listen once
         this.listeners = this.listeners.filter((l) => !l.once);
         return hadListeners;
-    }) as [T] extends [{}|null] ? (emitting: T) => boolean : () => boolean;
+        // eslint-disable-next-line @typescript-eslint/ban-types
+    }) as [T] extends [{} | null] ? (emitting: T) => boolean : () => boolean;
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -134,7 +134,7 @@ export class Event<T = undefined> {
         ? (emitting: T) => boolean
         : () => boolean = ((
         emitting?: T,
-    ) /* undefined only valid for singals */ => {
+    ) /* undefined only valid for signals */ => {
         const hadListeners = this.listeners.length > 0;
         for (const listener of this.listeners) {
             listener.callback(emitting as T);

--- a/src/event.ts
+++ b/src/event.ts
@@ -130,9 +130,9 @@ export class Event<T = undefined> {
      * be omitted.
      * @returns True if the event had listeners emitted to, false otherwise.
      */
-    public readonly emit: [T] extends [undefined]
-        ? () => boolean
-        : (emitting: T) => boolean = ((
+    public readonly emit: [T] extends [{}|null]
+        ? (emitting: T) => boolean
+        : () => boolean = ((
         emitting?: T,
     ) /* undefined only valid for singals */ => {
         const hadListeners = this.listeners.length > 0;
@@ -143,5 +143,5 @@ export class Event<T = undefined> {
         // remove all listeners that only wanted to listen once
         this.listeners = this.listeners.filter((l) => !l.once);
         return hadListeners;
-    }) as T extends undefined ? () => boolean : (data: T) => boolean;
+    }) as [T] extends [{}|null] ? (emitting: T) => boolean : () => boolean;
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -132,7 +132,9 @@ export class Event<T = undefined> {
      */
     // eslint-disable-next-line @typescript-eslint/ban-types
     public readonly emit: [T] extends [{} | null]
-        ? (emitting: T) => boolean
+        ? undefined extends T
+            ? (emitting?: T) => boolean
+            : (emitting: T) => boolean
         : () => boolean = ((
         emitting?: T,
     ) /* undefined only valid for signals */ => {
@@ -145,5 +147,9 @@ export class Event<T = undefined> {
         this.listeners = this.listeners.filter((l) => !l.once);
         return hadListeners;
         // eslint-disable-next-line @typescript-eslint/ban-types
-    }) as [T] extends [{} | null] ? (emitting: T) => boolean : () => boolean;
+    }) as [T] extends [{} | null]
+        ? undefined extends T
+            ? (emitting?: T) => boolean
+            : (emitting: T) => boolean
+        : () => boolean;
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -143,5 +143,5 @@ export class Event<T = undefined> {
         // remove all listeners that only wanted to listen once
         this.listeners = this.listeners.filter((l) => !l.once);
         return hadListeners;
-    }) as [T] extends [undefined] ? () => boolean : (data: T) => boolean;
+    }) as T extends undefined ? () => boolean : (data: T) => boolean;
 }


### PR DESCRIPTION
This PR fixes the following limitation:
```typescript
const event = new Event<any>();
event.emit("value"); // ts: Expected 0 arguments, but got 1.
```
Because of the way `emit` is typed, `Event<any>` will be interpreted as `Event<undefined>` and the resulting type signature will be `emit() => boolean` instead of `emit(data: any) => boolean`. So when you need to pass `any` value as payload, you're allowed none.

The need for an `Event<any>` arises when you want to emit an error event inside a try/catch clause for example, as the error is always of the `any` type.