### PR TITLE
Allow the creation of sealed events (and fix Event<any>)

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -23,13 +23,13 @@ export type Emitter<T = undefined> = [T] extends [{} | null]
     : () => boolean;
 
 export class Event<T = undefined> {
-    static createSealed<T = undefined>(): {
-        event: SealedEvent<T>;
+    static createSealed<T = undefined>(): readonly [Event<T>, Emitter<T>] & {
+        event: Event<T>;
         emit: Emitter<T>;
     } {
         const event = new this<T>();
         const emit = event.emit;
-        return { event, emit };
+        return Object.assign([event, emit] as const, { event, emit });
     }
 
     /** All the current listeners for this event. */

--- a/src/event.ts
+++ b/src/event.ts
@@ -16,11 +16,11 @@ interface Listener<T> {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type Emitter<T = undefined> = [T] extends [{} | null]
-    ? undefined extends T
-        ? (emitting?: T) => boolean
-        : (emitting: T) => boolean
-    : () => boolean;
+export type Emitter<T = undefined> = Exclude<T, undefined> extends never
+    ? () => boolean
+    : undefined extends T
+    ? (emitting?: T) => boolean
+    : (emitting: T) => boolean;
 
 export class Event<T = undefined> {
     static createSealed<T = undefined>(): readonly [Event<T>, Emitter<T>] & {

--- a/src/event.ts
+++ b/src/event.ts
@@ -23,6 +23,15 @@ export type Emitter<T> = [T] extends [{} | null]
     : () => boolean;
 
 export class Event<T = undefined> {
+    static createSealed<T = undefined>(): {
+        event: SealedEvent<T>;
+        emit: Emitter<T>;
+    } {
+        const event = new this<T>();
+        const emit = event.emit;
+        return { event, emit };
+    }
+
     /** All the current listeners for this event. */
     private listeners: Array<Listener<T>> = [];
 
@@ -150,3 +159,6 @@ export class Event<T = undefined> {
         return hadListeners;
     }) as Emitter<T>;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SealedEvent<T> extends Omit<Event<T>, "emit"> {}

--- a/src/event.ts
+++ b/src/event.ts
@@ -16,7 +16,7 @@ interface Listener<T> {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type Emitter<T> = [T] extends [{} | null]
+export type Emitter<T = undefined> = [T] extends [{} | null]
     ? undefined extends T
         ? (emitting?: T) => boolean
         : (emitting: T) => boolean
@@ -161,4 +161,4 @@ export class Event<T = undefined> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SealedEvent<T> extends Omit<Event<T>, "emit"> {}
+export interface SealedEvent<T = undefined> extends Omit<Event<T>, "emit"> {}

--- a/src/event.ts
+++ b/src/event.ts
@@ -15,6 +15,13 @@ interface Listener<T> {
     promise?: Promise<T>;
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type Emitter<T> = [T] extends [{} | null]
+    ? undefined extends T
+        ? (emitting?: T) => boolean
+        : (emitting: T) => boolean
+    : () => boolean;
+
 export class Event<T = undefined> {
     /** All the current listeners for this event. */
     private listeners: Array<Listener<T>> = [];
@@ -130,9 +137,7 @@ export class Event<T = undefined> {
      * be omitted.
      * @returns True if the event had listeners emitted to, false otherwise.
      */
-    public readonly emit: [T] extends [undefined]
-        ? () => boolean
-        : (emitting: T) => boolean = ((
+    public readonly emit: Emitter<T> = ((
         emitting?: T,
     ) /* undefined only valid for singals */ => {
         const hadListeners = this.listeners.length > 0;
@@ -143,5 +148,5 @@ export class Event<T = undefined> {
         // remove all listeners that only wanted to listen once
         this.listeners = this.listeners.filter((l) => !l.once);
         return hadListeners;
-    }) as [T] extends [undefined] ? () => boolean : (data: T) => boolean;
+    }) as Emitter<T>;
 }

--- a/test/event.test.ts
+++ b/test/event.test.ts
@@ -178,4 +178,61 @@ describe("Event", () => {
 
         expect(signal.emit()).toEqual(true); // emit with no data because this is a signal
     });
+
+    it("should allow events with any", () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const event = new Event<any>();
+
+        event.on((arg) => {
+            expect(arg).toEqual(100);
+        });
+
+        expect(event.emit(100)).toEqual(true);
+    });
+
+    it("should allow events with an union type", () => {
+        const event = new Event<number | string>();
+
+        // Test number
+        event.once((arg) => {
+            expect(arg).toEqual(100);
+        });
+        expect(event.emit(100)).toEqual(true);
+
+        // Test string
+        event.once((arg) => {
+            expect(arg).toEqual("test");
+        });
+        expect(event.emit("test")).toEqual(true);
+    });
+
+    it("should allow events with an union type including undefined", () => {
+        const event = new Event<
+            { key: string } | number | string | undefined
+        >();
+
+        // Test number
+        event.once((arg) => {
+            expect(arg).toEqual(100);
+        });
+        expect(event.emit(100)).toEqual(true);
+
+        // Test string
+        event.once((arg) => {
+            expect(arg).toEqual("test");
+        });
+        expect(event.emit("test")).toEqual(true);
+
+        // Test object
+        event.once((arg) => {
+            expect(arg).toEqual({ key: "test" });
+        });
+        expect(event.emit({ key: "test" })).toEqual(true);
+
+        // Test undefined (signal)
+        event.once((arg) => {
+            expect(arg).toBeUndefined();
+        });
+        expect(event.emit()).toEqual(true);
+    });
 });

--- a/test/sealed-event.test.ts
+++ b/test/sealed-event.test.ts
@@ -1,0 +1,23 @@
+import { Emitter, Event, SealedEvent } from "../src/";
+
+describe("SealedEvent", () => {
+    it("should construct", () => {
+        const {
+            event,
+            emit,
+        }: { event: SealedEvent; emit: Emitter } = Event.createSealed();
+        expect(event).toBeInstanceOf(Event);
+        expect(typeof emit).toBe("function");
+    });
+
+    it("should emit to listeners", () => {
+        const VAL = Symbol("emitTest");
+        const { event, emit } = Event.createSealed<typeof VAL>();
+        const fn = jest.fn((arg) => {
+            expect(arg).toBe(VAL);
+        });
+        event.on(fn);
+        expect(emit(VAL)).toBe(true);
+        expect(fn).toBeCalled();
+    });
+});

--- a/test/sealed-event.test.ts
+++ b/test/sealed-event.test.ts
@@ -1,11 +1,20 @@
 import { Emitter, Event, SealedEvent } from "../src/";
 
 describe("SealedEvent", () => {
-    it("should construct", () => {
+    it("should destructure as an object", () => {
         const {
             event,
             emit,
         }: { event: SealedEvent; emit: Emitter } = Event.createSealed();
+        expect(event).toBeInstanceOf(Event);
+        expect(typeof emit).toBe("function");
+    });
+
+    it("should destructure as an array", () => {
+        const [event, emit]: readonly [
+            SealedEvent,
+            Emitter,
+        ] = Event.createSealed();
         expect(event).toBeInstanceOf(Event);
         expect(typeof emit).toBe("function");
     });


### PR DESCRIPTION
## The problem
According to the `Promise` spec, only the instantiator of an instance has access to the `resolve` function:
```typescript
new Promise(resolve => ...);
```
This allows for Promises to be handed over to foreign code without having to worry that the end user accidentally resolves them with illegal values. In its current state, the typed `Event<T>` exposes its `emit` method for everyone to see and use, and given the compactness of the public interface this really stands out when trying to design a sturdy API.

## The proposed solution
In order to be able to seal this function away (like in the Promise spec) I propose the `Event.createSealed<T>()` constructor, which returns a `SealedEvent<T>` that does not expose the emit method. Usage is as follows:

```typescript
const { event, emit } = Event.createSealed<string>();
event.on(v => console.log(v));

event.emit("hello"); // Property 'emit' does not exist on type 'SealedEvent<number>'
emit("hello"); // hello
```
Because you receive the event and emitter separately at construction time, you can decide to store the event publicly while keeping the emitter private:
```typescript
class API {
    public onSignal: SealedEvent;
    private emitSignal: Emitter;

    constructor() {
        const { event, emit } = Event.createSealed();
        this.onSignal = event;
        this.emitSignal = emit;
    }

    ...

    private onReceiveSignal() {
        this.emitSignal();
    }
}
```
## Destructuring for compact notation
The result of `createSealed` can be destructured using object destructuring as shown above,
```typescript
const { event, emit } = Event.createSealed();
```
but it can also be destructured as an array.
```typescript
const [event, emit] = Event.createSealed();
```
This allows for virtually no syntactic overhead when using it inside a constructor.
```typescript
[this.event, this.emit] = Event.createSealed();
```