### PR TITLE
Allow for array destructuring

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ export type EventEmitter<T, TEvent extends Event<T>> = Emitter<T> & {
   event: TEvent;
   /** A cyclical reference to the same emitter function. */
   emit: Emitter<T>;
-};
+} & [TEvent, Emitter<T>];
 
 /** @internal */
 function createEmitterWithEvent<T, TEvent extends Event<T>>(
@@ -219,7 +219,7 @@ function createEmitterWithEvent<T, TEvent extends Event<T>>(
   func.event = event;
   func.emit = emit;
 
-  return func;
+  return Object.assign(func, [event, emit]);
 }
 
 /**

--- a/test/event-and-emit.test.ts
+++ b/test/event-and-emit.test.ts
@@ -27,6 +27,10 @@ createFunctions.forEach((create) =>
 
       expect(typeof returned.emit).toBe('function');
       expect(returned).toStrictEqual(returned.emit);
+
+      const [event, emit] = returned;
+      expect(event).toEqual(returned.event);
+      expect(emit).toEqual(returned.emit);
     });
 
     it('should emit to listeners on the event', () => {


### PR DESCRIPTION
The current object destructuring approach of `const {event, emit} = createEventEmitter()` is generally a nice approach, but gets cumbersome if you wish to create and assign several event/emitter pairs within the same scope (for example a constructor):
```typescript
class Example {
  eventA: Event;
  eventB: Event;
  eventC: Event;

  private emitA: Emitter;
  private emitB: Emitter;
  private emitC: Emitter;

  constructor() {
      const { event: eventA, emit: emitA } = createEventEmitter();
      const { event: eventB, emit: emitB } = createEventEmitter();
      const { event: eventC, emit: emitC } = createEventEmitter();

      this.eventA = eventA;
      this.eventB = eventB;
      this.eventC = eventC;
      
      this.emitA = emitA;
      this.emitB = emitB;
      this.emitC = emitC;
  }
}
```
For cases like this (not uncommon when exposing several events from within a class), array destructuring would be a very clean and welcome addition:
```typescript
class Example {
  eventA: Event;
  eventB: Event;
  eventC: Event;

  private emitA: Emitter;
  private emitB: Emitter;
  private emitC: Emitter;

  constructor() {
      [ this.eventA, this.emitA ] = createEventEmitter();
      [ this.eventB, this.emitB ] = createEventEmitter();
      [ this.eventC, this.emitC ] = createEventEmitter();
  }
}
```
This PR adds this functionality and provides the necessary tests to ensure both methods work consistently across both `createEventEmitter` and `createPublicEventEmitter`.